### PR TITLE
feat(backend): implement Redis event publishing for meeting status

### DIFF
--- a/backend/app/core/redis_client.py
+++ b/backend/app/core/redis_client.py
@@ -1,0 +1,20 @@
+import redis.asyncio as redis
+import os
+import json
+
+REDIS_URL = os.getenv("CELERY_BROKER_URL", "redis://redis:6379/0")
+NOTIFICATION_CHANNEL = "meeting_events"
+
+# Tworzymy pulę połączeń, która będzie reużywana
+pool = redis.ConnectionPool.from_url(REDIS_URL, decode_responses=True)
+
+async def publish_event(event_data: dict):
+    """Publikuje zdarzenie do kanału Redis."""
+    try:
+        # Pobieramy połączenie z puli
+        r = redis.Redis(connection_pool=pool)
+        message = json.dumps(event_data)
+        await r.publish(NOTIFICATION_CHANNEL, message)
+        print(f"Published event to {NOTIFICATION_CHANNEL}: {message}")
+    except Exception as e:
+        print(f"Error publishing Redis event: {e}")


### PR DESCRIPTION
This pull request introduces a Redis-based event publishing mechanism to notify about meeting processing updates and includes several adjustments to the `run_processing` function to integrate this functionality. The changes also improve error handling and ensure meeting data consistency during processing.

### Redis Integration for Event Publishing:

* **New Redis Client Module**: Added a new module `redis_client.py` with a connection pool and an `async def publish_event` function to publish events to a Redis channel (`backend/app/core/redis_client.py`, [backend/app/core/redis_client.pyR1-R20](diffhunk://#diff-9f435e5cc647499deb87ea6b44c042472e18c1a5efaf5c3238574e6de7b20180R1-R20)).
* **Event Publishing in `run_processing`**: Integrated the `publish_event` function to send a "meeting_processed" event with details such as meeting ID, project ID, uploader ID, processing status, and title when processing completes (`backend/app/worker/tasks.py`, [backend/app/worker/tasks.pyR101-R113](diffhunk://#diff-7bea0dd0eb34c590033edf9ece4cbf65514a7fd6a289d78eef64b528470c4601R101-R113)).

### Enhancements to `run_processing`:

* **Meeting Data Retrieval**: Ensured the `meeting` object is retrieved multiple times during the workflow to reflect the latest state, enhancing data consistency (`backend/app/worker/tasks.py`, [[1]](diffhunk://#diff-7bea0dd0eb34c590033edf9ece4cbf65514a7fd6a289d78eef64b528470c4601R36) [[2]](diffhunk://#diff-7bea0dd0eb34c590033edf9ece4cbf65514a7fd6a289d78eef64b528470c4601R69-R73).
* **Error Handling**: Added checks to raise an error if the meeting or its audio file is not found at critical stages of processing (`backend/app/worker/tasks.py`, [[1]](diffhunk://#diff-7bea0dd0eb34c590033edf9ece4cbf65514a7fd6a289d78eef64b528470c4601R36) [[2]](diffhunk://#diff-7bea0dd0eb34c590033edf9ece4cbf65514a7fd6a289d78eef64b528470c4601R69-R73).Add Redis PubSub event publishing mechanism after processing audio finishes. Worker Celery emits an event 'meeting.processed' with information about status. This is the first step for introducing WebSocket notifications